### PR TITLE
Omit nulls for splitted string

### DIFF
--- a/async-completing-read.el
+++ b/async-completing-read.el
@@ -124,7 +124,7 @@ If the metadata has no async property, just call
                              (prog1
                                  (buffer-substring last-pt new-pt)
                                (setq last-pt new-pt)))
-                           "\n")))))
+                           "\n" 'omit-nulls)))))
           (complete-with-action action lines string pred)))))
 
 (declare-function icomplete-exhibit "icomplete")


### PR DESCRIPTION
Hi there :)

I figured out default completing read omits them anyway so selectrum need to be updated for that. But I guess it doesn't harm to omit them here, too.
