### PR TITLE
Add function to preprocess candidates and a sentinel function

### DIFF
--- a/async-completing-read.el
+++ b/async-completing-read.el
@@ -86,7 +86,7 @@ If the metadata has no async property, just call
 `acr-completing-read-function' directly on COLLECTION."
   (if-let ((metadata (completion-metadata "" collection predicate))
            (async (completion-metadata-get metadata 'async))
-           (output-buffer (generate-new-buffer "*async-completing-read*"))
+           (output-buffer (generate-new-buffer " *async-completing-read*"))
            (update-timer (when acr-refresh-completion-ui
                            (run-with-timer
                             acr-refresh-completion-delay

--- a/async-completing-read.el
+++ b/async-completing-read.el
@@ -116,7 +116,8 @@ If the metadata has no async property, just call
         (kill-buffer output-buffer))
     (apply acr-completing-read-function prompt collection predicate args)))
 
-(defun acr-preprocess-lines-from-process (preprocess-fun
+(defun acr-preprocess-lines-from-process (category
+                                          preprocess-fun
                                           program &rest args)
   "Return a completion table for output lines from PROGRAM run with ARGS.
 PREPROCESS-FUN is a function that is passed the list of
@@ -125,7 +126,7 @@ candidates for pre-processing before it is accepted."
     (lambda (string pred action)
       (if (eq action 'metadata)
           `(metadata (async ,program ,@args)
-                     (category lines-from-process))
+                     (category . ,category))
         (when-let (output-buffer (funcall pred 'output-buffer))
           (when (buffer-live-p output-buffer)
             (with-current-buffer output-buffer
@@ -146,6 +147,7 @@ candidates for pre-processing before it is accepted."
 (defun acr-lines-from-process (program &rest args)
   "Return a completion table for output lines from PROGRAM run with ARGS."
   (apply 'acr-preprocess-lines-from-process
+         'lines-from-process
          'identity program args))
 
 (declare-function icomplete-exhibit "icomplete")


### PR DESCRIPTION
This pull request contains two commits:
- The first add a custom sentinel to the created process (called when the process exits) to kill the timer and the output buffer. Also with the default sentinel, a line is added to the output buffer "Process ... terminated" when the process finishes which is added as a candidate and specifying a custom sentinel prevents this.
- The second defines a new function `acr-preprocess-lines-from-process` which allows pre-processing lines before adding them as candidates.